### PR TITLE
Add automatic profile creation

### DIFF
--- a/src/main/java/com/cobijo/oca/service/UserService.java
+++ b/src/main/java/com/cobijo/oca/service/UserService.java
@@ -5,6 +5,7 @@ import com.cobijo.oca.domain.Authority;
 import com.cobijo.oca.domain.User;
 import com.cobijo.oca.repository.AuthorityRepository;
 import com.cobijo.oca.repository.UserRepository;
+import com.cobijo.oca.repository.UserProfileRepository;
 import com.cobijo.oca.security.AuthoritiesConstants;
 import com.cobijo.oca.security.SecurityUtils;
 import com.cobijo.oca.service.dto.AdminUserDTO;
@@ -41,16 +42,20 @@ public class UserService {
 
     private final CacheManager cacheManager;
 
+    private final UserProfileRepository userProfileRepository;
+
     public UserService(
         UserRepository userRepository,
         PasswordEncoder passwordEncoder,
         AuthorityRepository authorityRepository,
-        CacheManager cacheManager
+        CacheManager cacheManager,
+        UserProfileRepository userProfileRepository
     ) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.authorityRepository = authorityRepository;
         this.cacheManager = cacheManager;
+        this.userProfileRepository = userProfileRepository;
     }
 
     public Optional<User> activateRegistration(String key) {
@@ -130,6 +135,12 @@ public class UserService {
         authorityRepository.findById(AuthoritiesConstants.USER).ifPresent(authorities::add);
         newUser.setAuthorities(authorities);
         userRepository.save(newUser);
+        // create associated user profile
+        com.cobijo.oca.domain.UserProfile profile = new com.cobijo.oca.domain.UserProfile();
+        profile.setNickname(newUser.getLogin());
+        profile.setUser(newUser);
+        userProfileRepository.save(profile);
+
         this.clearUserCaches(newUser);
         LOG.debug("Created Information for User: {}", newUser);
         return newUser;
@@ -175,6 +186,12 @@ public class UserService {
             user.setAuthorities(authorities);
         }
         userRepository.save(user);
+        // create associated user profile
+        com.cobijo.oca.domain.UserProfile profile = new com.cobijo.oca.domain.UserProfile();
+        profile.setNickname(user.getLogin());
+        profile.setUser(user);
+        userProfileRepository.save(profile);
+
         this.clearUserCaches(user);
         LOG.debug("Created Information for User: {}", user);
         return user;

--- a/src/main/resources/config/liquibase/changelog/20250605182218_added_entity_UserProfile.xml
+++ b/src/main/resources/config/liquibase/changelog/20250605182218_added_entity_UserProfile.xml
@@ -46,6 +46,7 @@
             <column name="id" type="numeric"/>
             <column name="nickname" type="string"/>
             <column name="avatar_url" type="string"/>
+            <column name="user_id" type="numeric"/>
             <!-- jhipster-needle-liquibase-add-loadcolumn - JHipster (and/or extensions) can add load columns here -->
         </loadData>
     </changeSet>

--- a/src/main/resources/config/liquibase/fake-data/user_profile.csv
+++ b/src/main/resources/config/liquibase/fake-data/user_profile.csv
@@ -1,11 +1,13 @@
-id;nickname;avatar_url
-1;unto;terrible to psst
-2;energetically because inside;whistle lowball
-3;into if serve;drat fork abandoned
-4;familiar whenever;pendant t-shirt despite
-5;seriously instead manner;eventually inveigle arrogantly
-6;an;outside
-7;outstanding apropos inculcate;storyboard
-8;hydrant an finally;the and splurge
-9;hmph considering gosh;charm since
-10;firm;zowie
+id;nickname;avatar_url;user_id
+1;unto;terrible to psst;
+2;energetically because inside;whistle lowball;
+3;into if serve;drat fork abandoned;
+4;familiar whenever;pendant t-shirt despite;
+5;seriously instead manner;eventually inveigle arrogantly;
+6;an;outside;
+7;outstanding apropos inculcate;storyboard;
+8;hydrant an finally;the and splurge;
+9;hmph considering gosh;charm since;
+10;firm;zowie;
+11;admin;;1
+12;user;;2


### PR DESCRIPTION
## Summary
- connect `UserService` with `UserProfileRepository`
- create a user profile when a new user is registered or created
- add profile entries in fake data for default admin and user

## Testing
- `./mvnw -q -DskipTests=true test-compile` *(fails: Network is unreachable)*
- `./npmw test --silent` *(fails: cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6848a9cfa18c8322bdcf2078cf0a61eb