### PR TITLE
Implement game room creation and join via link

### DIFF
--- a/src/main/java/com/cobijo/oca/repository/GameRepository.java
+++ b/src/main/java/com/cobijo/oca/repository/GameRepository.java
@@ -27,4 +27,10 @@ public interface GameRepository extends GameRepositoryWithBagRelationships, JpaR
     default Page<Game> findAllWithEagerRelationships(Pageable pageable) {
         return this.fetchBagRelationships(this.findAll(pageable));
     }
+
+    Optional<Game> findOneByCode(String code);
+
+    default Optional<Game> findOneWithEagerRelationshipsByCode(String code) {
+        return this.fetchBagRelationships(this.findOneByCode(code));
+    }
 }

--- a/src/main/java/com/cobijo/oca/service/GameService.java
+++ b/src/main/java/com/cobijo/oca/service/GameService.java
@@ -1,10 +1,12 @@
 package com.cobijo.oca.service;
 
 import com.cobijo.oca.domain.Game;
+import com.cobijo.oca.domain.enumeration.GameStatus;
 import com.cobijo.oca.repository.GameRepository;
 import com.cobijo.oca.service.dto.GameDTO;
 import com.cobijo.oca.service.mapper.GameMapper;
 import java.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -52,6 +54,14 @@ public class GameService {
     public GameDTO update(GameDTO gameDTO) {
         LOG.debug("Request to update Game : {}", gameDTO);
         Game game = gameMapper.toEntity(gameDTO);
+        game = gameRepository.save(game);
+        return gameMapper.toDto(game);
+    }
+
+    public GameDTO createRoom() {
+        Game game = new Game();
+        game.setCode(RandomStringUtils.randomAlphanumeric(6));
+        game.setStatus(GameStatus.WAITING);
         game = gameRepository.save(game);
         return gameMapper.toDto(game);
     }
@@ -107,6 +117,12 @@ public class GameService {
     public Optional<GameDTO> findOne(Long id) {
         LOG.debug("Request to get Game : {}", id);
         return gameRepository.findOneWithEagerRelationships(id).map(gameMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<GameDTO> findOneByCode(String code) {
+        LOG.debug("Request to get Game by code : {}", code);
+        return gameRepository.findOneWithEagerRelationshipsByCode(code).map(gameMapper::toDto);
     }
 
     /**

--- a/src/main/java/com/cobijo/oca/web/rest/GameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/GameResource.java
@@ -71,6 +71,12 @@ public class GameResource {
             .body(gameDTO);
     }
 
+    @PostMapping("/create-room")
+    public ResponseEntity<GameDTO> createRoom() throws URISyntaxException {
+        GameDTO gameDTO = gameService.createRoom();
+        return ResponseEntity.created(new URI("/api/games/" + gameDTO.getId())).body(gameDTO);
+    }
+
     /**
      * {@code PUT  /games/:id} : Updates an existing game.
      *
@@ -175,6 +181,13 @@ public class GameResource {
     public ResponseEntity<GameDTO> getGame(@PathVariable("id") Long id) {
         LOG.debug("REST request to get Game : {}", id);
         Optional<GameDTO> gameDTO = gameService.findOne(id);
+        return ResponseUtil.wrapOrNotFound(gameDTO);
+    }
+
+    @GetMapping("/code/{code}")
+    public ResponseEntity<GameDTO> getGameByCode(@PathVariable("code") String code) {
+        LOG.debug("REST request to get Game by code : {}", code);
+        Optional<GameDTO> gameDTO = gameService.findOneByCode(code);
         return ResponseUtil.wrapOrNotFound(gameDTO);
     }
 

--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -34,6 +34,10 @@ const routes: Routes = [
     title: 'Inicio de Sesión',
   },
   {
+    path: 'room',
+    loadChildren: () => import('./room/room.routes'),
+  },
+  {
     path: '',
     loadChildren: () => import(`./entities/entity.routes`),
   },

--- a/src/main/webapp/app/entities/game/service/game.service.ts
+++ b/src/main/webapp/app/entities/game/service/game.service.ts
@@ -44,6 +44,14 @@ export class GameService {
     return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response' });
   }
 
+  createRoom(): Observable<EntityResponseType> {
+    return this.http.post<IGame>(`${this.resourceUrl}/create-room`, {}, { observe: 'response' });
+  }
+
+  findByCode(code: string): Observable<EntityResponseType> {
+    return this.http.get<IGame>(`${this.resourceUrl}/code/${code}`, { observe: 'response' });
+  }
+
   getGameIdentifier(game: Pick<IGame, 'id'>): number {
     return game.id;
   }

--- a/src/main/webapp/app/home/home.component.html
+++ b/src/main/webapp/app/home/home.component.html
@@ -1,1 +1,2 @@
+<button class="btn btn-primary mb-3" (click)="createRoom()">Crear sala</button>
 <jhi-phaser-game></jhi-phaser-game>

--- a/src/main/webapp/app/home/home.component.spec.ts
+++ b/src/main/webapp/app/home/home.component.spec.ts
@@ -7,11 +7,13 @@ jest.mock('phaser', () => ({
 }));
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Subject, of } from 'rxjs';
 
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/auth/account.model';
+import { GameService } from 'app/entities/game/service/game.service';
 
 import HomeComponent from './home.component';
 
@@ -34,7 +36,7 @@ describe('Home Component', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HomeComponent],
-      providers: [AccountService],
+      providers: [AccountService, GameService, provideHttpClient()],
     })
       .overrideTemplate(HomeComponent, '')
       .compileComponents();

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -7,6 +7,7 @@ import SharedModule from 'app/shared/shared.module';
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/auth/account.model';
 import { PhaserGameComponent } from '../phaser-game/phaser-game.component';
+import { GameService } from 'app/entities/game/service/game.service';
 
 @Component({
   selector: 'jhi-home',
@@ -21,6 +22,7 @@ export default class HomeComponent implements OnInit, OnDestroy {
 
   private readonly accountService = inject(AccountService);
   private readonly router = inject(Router);
+  private readonly gameService = inject(GameService);
 
   ngOnInit(): void {
     this.accountService
@@ -37,6 +39,15 @@ export default class HomeComponent implements OnInit, OnDestroy {
 
   login(): void {
     this.router.navigate(['/login']);
+  }
+
+  createRoom(): void {
+    this.gameService.createRoom().subscribe(res => {
+      const code = res.body?.code;
+      if (code) {
+        this.router.navigate(['/room', code]);
+      }
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/main/webapp/app/room/room.component.html
+++ b/src/main/webapp/app/room/room.component.html
@@ -1,0 +1,5 @@
+<div class="mb-3">
+  <label>Enlace para compartir:</label>
+  <input type="text" class="form-control" [value]="shareLink()" readonly />
+</div>
+<jhi-phaser-game *ngIf="game()"></jhi-phaser-game>

--- a/src/main/webapp/app/room/room.component.ts
+++ b/src/main/webapp/app/room/room.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import SharedModule from 'app/shared/shared.module';
+import { PhaserGameComponent } from '../phaser-game/phaser-game.component';
+import { GameService } from '../entities/game/service/game.service';
+import { IGame } from '../entities/game/game.model';
+
+@Component({
+  selector: 'jhi-room',
+  standalone: true,
+  imports: [SharedModule, RouterModule, PhaserGameComponent],
+  templateUrl: './room.component.html',
+})
+export default class RoomComponent implements OnInit {
+  game = signal<IGame | null>(null);
+  shareLink = signal('');
+
+  private readonly route = inject(ActivatedRoute);
+  private readonly gameService = inject(GameService);
+
+  ngOnInit(): void {
+    const code = this.route.snapshot.paramMap.get('code')!;
+    this.shareLink.set(`${location.origin}/room/${code}`);
+    this.gameService.findByCode(code).subscribe(res => {
+      this.game.set(res.body ?? null);
+    });
+  }
+}

--- a/src/main/webapp/app/room/room.routes.ts
+++ b/src/main/webapp/app/room/room.routes.ts
@@ -1,0 +1,13 @@
+import { Routes } from '@angular/router';
+import { UserRouteAccessService } from 'app/core/auth/user-route-access.service';
+
+const roomRoutes: Routes = [
+  {
+    path: ':code',
+    loadComponent: () => import('./room.component'),
+    canActivate: [UserRouteAccessService],
+    data: { pageTitle: 'Sala' },
+  },
+];
+
+export default roomRoutes;


### PR DESCRIPTION
## Summary
- add repository methods to search game by code
- create game room in service with random code
- expose create-room and code endpoints
- add Angular room component and routes
- show create room button on home
- extend game service for createRoom and findByCode
- adjust tests with GameService provider

## Testing
- `npm test`
- `./mvnw -ntp verify -DskipTests` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6848aab97f5883228387bd5754931c85