### PR TITLE
Enable guests to join game rooms

### DIFF
--- a/src/main/java/com/cobijo/oca/config/SecurityConfiguration.java
+++ b/src/main/java/com/cobijo/oca/config/SecurityConfiguration.java
@@ -67,6 +67,8 @@ public class SecurityConfiguration {
                     .requestMatchers(mvc.pattern(HttpMethod.GET, "/api/authenticate")).permitAll()
                     .requestMatchers(mvc.pattern(HttpMethod.POST, "/api/user-profiles/guest")).permitAll()
                     .requestMatchers(mvc.pattern(HttpMethod.GET, "/api/user-profiles/session/**")).permitAll()
+                    .requestMatchers(mvc.pattern(HttpMethod.GET, "/api/games/code/**")).permitAll()
+                    .requestMatchers(mvc.pattern(HttpMethod.POST, "/api/player-games")).permitAll()
                     .requestMatchers(mvc.pattern("/api/register")).permitAll()
                     .requestMatchers(mvc.pattern("/api/activate")).permitAll()
                     .requestMatchers(mvc.pattern("/api/account/reset-password/init")).permitAll()

--- a/src/main/webapp/app/core/auth/auth-jwt.service.ts
+++ b/src/main/webapp/app/core/auth/auth-jwt.service.ts
@@ -9,6 +9,7 @@ import { StateStorageService } from './state-storage.service';
 
 type JwtToken = {
   id_token: string;
+  session_id?: string;
 };
 
 @Injectable({ providedIn: 'root' })
@@ -36,5 +37,8 @@ export class AuthServerProvider {
 
   private authenticateSuccess(response: JwtToken, rememberMe: boolean): void {
     this.stateStorageService.storeAuthenticationToken(response.id_token, rememberMe);
+    if (response.session_id) {
+      localStorage.setItem('session_id', response.session_id);
+    }
   }
 }

--- a/src/main/webapp/app/entities/user-profile/service/user-profile.service.ts
+++ b/src/main/webapp/app/entities/user-profile/service/user-profile.service.ts
@@ -39,6 +39,10 @@ export class UserProfileService {
     return this.http.get<IUserProfile>(`${this.resourceUrl}/${id}`, { observe: 'response' });
   }
 
+  findBySession(sessionId: string): Observable<EntityResponseType> {
+    return this.http.get<IUserProfile>(`${this.resourceUrl}/session/${sessionId}`, { observe: 'response' });
+  }
+
   query(req?: any): Observable<EntityArrayResponseType> {
     const options = createRequestOption(req);
     return this.http.get<IUserProfile[]>(this.resourceUrl, { params: options, observe: 'response' });

--- a/src/main/webapp/app/login/login.component.ts
+++ b/src/main/webapp/app/login/login.component.ts
@@ -5,6 +5,7 @@ import { Router, RouterModule } from '@angular/router';
 import SharedModule from 'app/shared/shared.module';
 import { LoginService } from 'app/login/login.service';
 import { AccountService } from 'app/core/auth/account.service';
+import { StateStorageService } from 'app/core/auth/state-storage.service';
 import { IUserProfile } from 'app/entities/user-profile/user-profile.model';
 
 @Component({
@@ -30,6 +31,7 @@ export default class LoginComponent implements OnInit, AfterViewInit {
   private readonly accountService = inject(AccountService);
   private readonly loginService = inject(LoginService);
   private readonly router = inject(Router);
+  private readonly stateStorageService = inject(StateStorageService);
 
   ngOnInit(): void {
     // if already authenticated then navigate to home page
@@ -62,7 +64,13 @@ export default class LoginComponent implements OnInit, AfterViewInit {
     this.loginService.guestLogin(nickname).subscribe({
       next: (profile: IUserProfile) => {
         localStorage.setItem('session_id', profile.sessionId ?? '');
-        this.router.navigate(['']);
+        const previousUrl = this.stateStorageService.getUrl();
+        if (previousUrl) {
+          this.stateStorageService.clearUrl();
+          this.router.navigateByUrl(previousUrl);
+        } else {
+          this.router.navigate(['']);
+        }
       },
     });
   }

--- a/src/main/webapp/app/room/room.component.ts
+++ b/src/main/webapp/app/room/room.component.ts
@@ -4,6 +4,9 @@ import SharedModule from 'app/shared/shared.module';
 import { PhaserGameComponent } from '../phaser-game/phaser-game.component';
 import { GameService } from '../entities/game/service/game.service';
 import { IGame } from '../entities/game/game.model';
+import { UserProfileService } from '../entities/user-profile/service/user-profile.service';
+import { PlayerGameService } from '../entities/player-game/service/player-game.service';
+import { NewPlayerGame } from '../entities/player-game/player-game.model';
 
 @Component({
   selector: 'jhi-room',
@@ -17,12 +20,35 @@ export default class RoomComponent implements OnInit {
 
   private readonly route = inject(ActivatedRoute);
   private readonly gameService = inject(GameService);
+  private readonly userProfileService = inject(UserProfileService);
+  private readonly playerGameService = inject(PlayerGameService);
 
   ngOnInit(): void {
     const code = this.route.snapshot.paramMap.get('code')!;
     this.shareLink.set(`${location.origin}/room/${code}`);
     this.gameService.findByCode(code).subscribe(res => {
-      this.game.set(res.body ?? null);
+      const game = res.body ?? null;
+      this.game.set(game);
+      if (game) {
+        const sessionId = localStorage.getItem('session_id');
+        if (sessionId) {
+          this.userProfileService.findBySession(sessionId).subscribe(profileRes => {
+            const profile = profileRes.body;
+            if (profile && profile.id != null && game.id != null) {
+              const player: NewPlayerGame = {
+                id: null,
+                positionx: 0,
+                positiony: 0,
+                order: 0,
+                isWinner: false,
+                game: { id: game.id },
+                userProfile: { id: profile.id },
+              };
+              this.playerGameService.create(player).subscribe();
+            }
+          });
+        }
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- allow unauthenticated requests to join rooms
- persist login session id from JWT response
- expose GET user profile by session id to the frontend
- redirect guest login to previously stored URL
- auto-create `PlayerGame` on room load

## Testing
- `./mvnw -q verify` *(fails: Non-resolvable parent POM)*
- `./npmw test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6848afb90bdc8322a26acda0a71a8b91