### PR TITLE
Add board turn logic with dice

### DIFF
--- a/src/main/java/com/cobijo/oca/repository/PlayerGameRepository.java
+++ b/src/main/java/com/cobijo/oca/repository/PlayerGameRepository.java
@@ -1,6 +1,7 @@
 package com.cobijo.oca.repository;
 
 import com.cobijo.oca.domain.PlayerGame;
+import java.util.List;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,7 @@ import org.springframework.stereotype.Repository;
  */
 @SuppressWarnings("unused")
 @Repository
-public interface PlayerGameRepository extends JpaRepository<PlayerGame, Long> {}
+public interface PlayerGameRepository extends JpaRepository<PlayerGame, Long> {
+
+    List<PlayerGame> findByGameId(Long gameId);
+}

--- a/src/main/java/com/cobijo/oca/service/PlayerGameService.java
+++ b/src/main/java/com/cobijo/oca/service/PlayerGameService.java
@@ -4,7 +4,9 @@ import com.cobijo.oca.domain.PlayerGame;
 import com.cobijo.oca.repository.PlayerGameRepository;
 import com.cobijo.oca.service.dto.PlayerGameDTO;
 import com.cobijo.oca.service.mapper.PlayerGameMapper;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -86,6 +88,16 @@ public class PlayerGameService {
     public Page<PlayerGameDTO> findAll(Pageable pageable) {
         LOG.debug("Request to get all PlayerGames");
         return playerGameRepository.findAll(pageable).map(playerGameMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlayerGameDTO> findByGameId(Long gameId) {
+        LOG.debug("Request to get PlayerGames by game : {}", gameId);
+        return playerGameRepository
+            .findByGameId(gameId)
+            .stream()
+            .map(playerGameMapper::toDto)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/cobijo/oca/web/rest/PlayerGameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/PlayerGameResource.java
@@ -149,6 +149,13 @@ public class PlayerGameResource {
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
 
+    @GetMapping("/game/{gameId}")
+    public ResponseEntity<List<PlayerGameDTO>> getPlayerGamesByGame(@PathVariable("gameId") Long gameId) {
+        LOG.debug("REST request to get PlayerGames by game : {}", gameId);
+        List<PlayerGameDTO> list = playerGameService.findByGameId(gameId);
+        return ResponseEntity.ok().body(list);
+    }
+
     /**
      * {@code GET  /player-games/:id} : get the "id" playerGame.
      *

--- a/src/main/webapp/app/entities/player-game/service/player-game.service.ts
+++ b/src/main/webapp/app/entities/player-game/service/player-game.service.ts
@@ -44,6 +44,10 @@ export class PlayerGameService {
     return this.http.get<IPlayerGame[]>(this.resourceUrl, { params: options, observe: 'response' });
   }
 
+  findByGame(gameId: number): Observable<IPlayerGame[]> {
+    return this.http.get<IPlayerGame[]>(`${this.resourceUrl}/game/${gameId}`);
+  }
+
   delete(id: number): Observable<HttpResponse<{}>> {
     return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response' });
   }
@@ -62,7 +66,9 @@ export class PlayerGameService {
   ): Type[] {
     const playerGames: Type[] = playerGamesToCheck.filter(isPresent);
     if (playerGames.length > 0) {
-      const playerGameCollectionIdentifiers = playerGameCollection.map(playerGameItem => this.getPlayerGameIdentifier(playerGameItem));
+      const playerGameCollectionIdentifiers = playerGameCollection.map(playerGameItem =>
+        this.getPlayerGameIdentifier(playerGameItem)
+      );
       const playerGamesToAdd = playerGames.filter(playerGameItem => {
         const playerGameIdentifier = this.getPlayerGameIdentifier(playerGameItem);
         if (playerGameCollectionIdentifiers.includes(playerGameIdentifier)) {

--- a/src/main/webapp/app/phaser-game/phaser-game.component.html
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.html
@@ -1,1 +1,5 @@
+<div class="mb-2">
+  <button class="btn btn-primary" (click)="rollDice()">Tirar dado</button>
+  <span class="ms-2" *ngIf="diceValue">Dado: {{ diceValue }}</span>
+</div>
 <div #gameContainer></div>

--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -1,6 +1,9 @@
-import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import Phaser from 'phaser';
-import { MainScene } from './scene';
+import { MainScene, PlayerToken } from './scene';
+import { IGame } from 'app/entities/game/game.model';
+import { IPlayerGame } from 'app/entities/player-game/player-game.model';
+import { PlayerGameService } from 'app/entities/player-game/service/player-game.service';
 
 @Component({
   selector: 'jhi-phaser-game',
@@ -9,19 +12,50 @@ import { MainScene } from './scene';
   styleUrl: './phaser-game.component.scss',
 })
 export class PhaserGameComponent implements OnDestroy, OnInit {
+  @Input({ required: true }) game: IGame | null = null;
   @ViewChild('gameContainer', { static: true }) gameContainer!: ElementRef;
 
+  diceValue = 0;
+  currentTurn = 0;
+  private players: IPlayerGame[] = [];
   private phaserGame?: Phaser.Game;
+  private scene?: MainScene;
+
+  private readonly playerGameService = inject(PlayerGameService);
 
   ngOnInit(): void {
+    if (!this.game?.id) {
+      return;
+    }
+    this.playerGameService.findByGame(this.game.id).subscribe(players => {
+      this.players = players;
+      this.startGame();
+    });
+  }
+
+  rollDice(): void {
+    if (!this.scene || this.players.length === 0) {
+      return;
+    }
+    this.diceValue = Phaser.Math.Between(1, 6);
+    this.scene.movePlayer(this.currentTurn, this.diceValue);
+    this.currentTurn = (this.currentTurn + 1) % this.players.length;
+  }
+
+  private startGame(): void {
+    const tokens: PlayerToken[] = this.players.map(p => ({
+      id: p.id!,
+      color: Phaser.Display.Color.RandomRGB().color,
+      position: 0,
+    }));
+    this.scene = new MainScene(tokens);
     const config: Phaser.Types.Core.GameConfig = {
       type: Phaser.AUTO,
       width: 800,
       height: 600,
       parent: this.gameContainer.nativeElement,
-      scene: [MainScene],
+      scene: [this.scene],
     };
-
     this.phaserGame = new Phaser.Game(config);
   }
 

--- a/src/main/webapp/app/phaser-game/scene.ts
+++ b/src/main/webapp/app/phaser-game/scene.ts
@@ -1,14 +1,20 @@
 import Phaser from 'phaser';
 
-const BOARD_ROWS = 8;
-const BOARD_COLS = 8;
-const TILE_SIZE = 64;
+export const BOARD_ROWS = 8;
+export const BOARD_COLS = 8;
+export const TILE_SIZE = 64;
+export interface PlayerToken {
+  id: number;
+  color: number;
+  position: number;
+  sprite?: Phaser.GameObjects.Arc;
+}
+
 export class MainScene extends Phaser.Scene {
-  private token!: Phaser.GameObjects.Image;
-  private piece!: Phaser.GameObjects.Image;
-  private position = { row: 0, col: 0 };
-  constructor() {
+  private players: PlayerToken[] = [];
+  constructor(players: PlayerToken[]) {
     super({ key: 'MainScene' });
+    this.players = players;
   }
 
   preload(): void {
@@ -18,55 +24,40 @@ export class MainScene extends Phaser.Scene {
   create(): void {
     const board = this.add.image(0, 0, 'board').setOrigin(0, 0);
 
-    // Escalar para que llene toda el área
     board.setDisplaySize(this.scale.width, this.scale.height);
-    // this.add.image(400, 300, 'board');
     for (let row = 0; row < BOARD_ROWS; row++) {
       for (let col = 0; col < BOARD_COLS; col++) {
         const x = col * TILE_SIZE;
         const y = row * TILE_SIZE;
-        // Opción 1: dibujar con gráficos
         const color = (row + col) % 2 === 0 ? 0xffffff : 0xcccccc;
         const rect = this.add.rectangle(x + TILE_SIZE / 2, y + TILE_SIZE / 2, TILE_SIZE, TILE_SIZE, color);
         rect.setStrokeStyle(1, 0x000000);
       }
     }
-    // Crear ficha
-    const startX = this.position.col * TILE_SIZE + TILE_SIZE / 2;
-    const startY = this.position.row * TILE_SIZE + TILE_SIZE / 2;
-    this.piece = this.add.image(startX, startY, 'piece').setDisplaySize(48, 48);
-
-    // Configurar input de flechas
-    this.input.keyboard?.on('keydown', (event: KeyboardEvent) => {
-      if (event.key === 'ArrowUp' && this.position.row > 0) {
-        this.position.row--;
-      }
-      if (event.key === 'ArrowDown' && this.position.row < BOARD_ROWS - 1) {
-        this.position.row++;
-      }
-      if (event.key === 'ArrowLeft' && this.position.col > 0) {
-        this.position.col--;
-      }
-      if (event.key === 'ArrowRight' && this.position.col < BOARD_COLS - 1) {
-        this.position.col++;
-      }
-
-      // Mover la ficha a la nueva posición
-      const newX = this.position.col * TILE_SIZE + TILE_SIZE / 2;
-      const newY = this.position.row * TILE_SIZE + TILE_SIZE / 2;
-      this.piece.setPosition(newX, newY);
-      // this.add.image(400, 300, 'board');
-      // this.token = this.add.image(100, 100, 'token');
-
-      // // Ejemplo: mover ficha al hacer clic
-      // this.input.on('pointerdown', () => {
-      //   this.tweens.add({
-      //     targets: this.token,
-      //     x: this.token.x + 64,
-      //     duration: 300,
-      //     ease: 'Power2',
-      //   });
-      // });
+    this.players.forEach(p => {
+      const { row, col } = this.indexToCoord(p.position);
+      p.sprite = this.add.circle(col * TILE_SIZE + TILE_SIZE / 2, row * TILE_SIZE + TILE_SIZE / 2, 20, p.color);
     });
+  }
+
+  movePlayer(index: number, steps: number): void {
+    const player = this.players[index];
+    player.position = (player.position + steps) % (BOARD_ROWS * BOARD_COLS);
+    const { row, col } = this.indexToCoord(player.position);
+    if (player.sprite) {
+      this.tweens.add({
+        targets: player.sprite,
+        x: col * TILE_SIZE + TILE_SIZE / 2,
+        y: row * TILE_SIZE + TILE_SIZE / 2,
+        duration: 300,
+        ease: 'Power2',
+      });
+    }
+  }
+
+  private indexToCoord(index: number): { row: number; col: number } {
+    const row = Math.floor(index / BOARD_COLS);
+    const col = index % BOARD_COLS;
+    return { row, col };
   }
 }

--- a/src/main/webapp/app/room/room.component.html
+++ b/src/main/webapp/app/room/room.component.html
@@ -2,4 +2,4 @@
   <label>Enlace para compartir:</label>
   <input type="text" class="form-control" [value]="shareLink()" readonly />
 </div>
-<jhi-phaser-game *ngIf="game()"></jhi-phaser-game>
+<jhi-phaser-game *ngIf="game()" [game]="game()"></jhi-phaser-game>


### PR DESCRIPTION
## Summary
- link PlayerGame records to a Game via repository method
- expose endpoint to list PlayerGame by game
- add service method to fetch players by game
- render each player as a piece on the Phaser board
- implement simple dice and turn logic
- show board in room component with game input

## Testing
- `./mvnw -ntp test` *(fails: Non-resolvable parent POM)*
- `./npmw test --silent` *(fails: cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6848b49f8a708322b32883ab68f00d55