### PR TITLE
Update home and room flow

### DIFF
--- a/src/main/webapp/app/entities/player-game/service/player-game.service.ts
+++ b/src/main/webapp/app/entities/player-game/service/player-game.service.ts
@@ -66,9 +66,7 @@ export class PlayerGameService {
   ): Type[] {
     const playerGames: Type[] = playerGamesToCheck.filter(isPresent);
     if (playerGames.length > 0) {
-      const playerGameCollectionIdentifiers = playerGameCollection.map(playerGameItem =>
-        this.getPlayerGameIdentifier(playerGameItem)
-      );
+      const playerGameCollectionIdentifiers = playerGameCollection.map(playerGameItem => this.getPlayerGameIdentifier(playerGameItem));
       const playerGamesToAdd = playerGames.filter(playerGameItem => {
         const playerGameIdentifier = this.getPlayerGameIdentifier(playerGameItem);
         if (playerGameCollectionIdentifiers.includes(playerGameIdentifier)) {

--- a/src/main/webapp/app/home/home.component.html
+++ b/src/main/webapp/app/home/home.component.html
@@ -1,2 +1,8 @@
 <button class="btn btn-primary mb-3" (click)="createRoom()">Crear sala</button>
-<jhi-phaser-game></jhi-phaser-game>
+
+<ul class="list-group">
+  <li *ngFor="let game of games()" class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ game.code }} - {{ game.status }}</span>
+    <button class="btn btn-link" (click)="openGame(game)">Entrar</button>
+  </li>
+</ul>

--- a/src/main/webapp/app/phaser-game/phaser-game.component.spec.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.spec.ts
@@ -8,6 +8,7 @@ jest.mock('phaser', () => ({
 }));
 
 import { PhaserGameComponent } from './phaser-game.component';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('PhaserGameComponent', () => {
   let component: PhaserGameComponent;
@@ -16,6 +17,7 @@ describe('PhaserGameComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PhaserGameComponent],
+      providers: [provideHttpClient()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PhaserGameComponent);

--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -42,9 +42,13 @@ export class PhaserGameComponent implements OnDestroy, OnInit {
     this.currentTurn = (this.currentTurn + 1) % this.players.length;
   }
 
+  ngOnDestroy(): void {
+    this.phaserGame?.destroy(true);
+  }
+
   private startGame(): void {
     const tokens: PlayerToken[] = this.players.map(p => ({
-      id: p.id!,
+      id: p.id,
       color: Phaser.Display.Color.RandomRGB().color,
       position: 0,
     }));
@@ -57,9 +61,5 @@ export class PhaserGameComponent implements OnDestroy, OnInit {
       scene: [this.scene],
     };
     this.phaserGame = new Phaser.Game(config);
-  }
-
-  ngOnDestroy(): void {
-    this.phaserGame?.destroy(true);
   }
 }

--- a/src/main/webapp/app/room/room.component.html
+++ b/src/main/webapp/app/room/room.component.html
@@ -2,4 +2,4 @@
   <label>Enlace para compartir:</label>
   <input type="text" class="form-control" [value]="shareLink()" readonly />
 </div>
-<jhi-phaser-game *ngIf="game()" [game]="game()"></jhi-phaser-game>
+<jhi-phaser-game *ngIf="game() && game()!.status === 'IN_PROGRESS'" [game]="game()"></jhi-phaser-game>

--- a/src/main/webapp/app/room/room.component.ts
+++ b/src/main/webapp/app/room/room.component.ts
@@ -34,7 +34,7 @@ export default class RoomComponent implements OnInit {
         if (sessionId) {
           this.userProfileService.findBySession(sessionId).subscribe(profileRes => {
             const profile = profileRes.body;
-            if (profile && profile.id != null && game.id != null) {
+            if (profile?.id != null) {
               const player: NewPlayerGame = {
                 id: null,
                 positionx: 0,


### PR DESCRIPTION
## Summary
- show user's game rooms on home page
- only start Phaser game when status is IN_PROGRESS
- add http client in Phaser game tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b90d8ff48322979b71a8a039b15b