### PR TITLE
Add start game and player list

### DIFF
--- a/src/main/java/com/cobijo/oca/service/GameService.java
+++ b/src/main/java/com/cobijo/oca/service/GameService.java
@@ -66,6 +66,14 @@ public class GameService {
         return gameMapper.toDto(game);
     }
 
+    public GameDTO startGame(Long id) {
+        LOG.debug("Request to start Game : {}", id);
+        Game game = gameRepository.findById(id).orElseThrow();
+        game.setStatus(GameStatus.IN_PROGRESS);
+        game = gameRepository.save(game);
+        return gameMapper.toDto(game);
+    }
+
     /**
      * Partially update a game.
      *

--- a/src/main/java/com/cobijo/oca/service/mapper/PlayerGameMapper.java
+++ b/src/main/java/com/cobijo/oca/service/mapper/PlayerGameMapper.java
@@ -14,7 +14,7 @@ import org.mapstruct.*;
 @Mapper(componentModel = "spring")
 public interface PlayerGameMapper extends EntityMapper<PlayerGameDTO, PlayerGame> {
     @Mapping(target = "game", source = "game", qualifiedByName = "gameId")
-    @Mapping(target = "userProfile", source = "userProfile", qualifiedByName = "userProfileId")
+    @Mapping(target = "userProfile", source = "userProfile")
     PlayerGameDTO toDto(PlayerGame s);
 
     @Named("gameId")

--- a/src/main/java/com/cobijo/oca/web/rest/GameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/GameResource.java
@@ -77,6 +77,14 @@ public class GameResource {
         return ResponseEntity.created(new URI("/api/games/" + gameDTO.getId())).body(gameDTO);
     }
 
+    @PostMapping("/{id}/start")
+    public ResponseEntity<GameDTO> startGame(@PathVariable("id") Long id) {
+        LOG.debug("REST request to start Game : {}", id);
+        GameDTO gameDTO = gameService.startGame(id);
+        gameWebsocketService.sendGameUpdate(gameDTO);
+        return ResponseEntity.ok().body(gameDTO);
+    }
+
     /**
      * {@code PUT  /games/:id} : Updates an existing game.
      *

--- a/src/main/webapp/app/entities/game/service/game.service.ts
+++ b/src/main/webapp/app/entities/game/service/game.service.ts
@@ -48,6 +48,10 @@ export class GameService {
     return this.http.post<IGame>(`${this.resourceUrl}/create-room`, {}, { observe: 'response' });
   }
 
+  start(id: number): Observable<EntityResponseType> {
+    return this.http.post<IGame>(`${this.resourceUrl}/${id}/start`, {}, { observe: 'response' });
+  }
+
   findByCode(code: string): Observable<EntityResponseType> {
     return this.http.get<IGame>(`${this.resourceUrl}/code/${code}`, { observe: 'response' });
   }

--- a/src/main/webapp/app/entities/player-game/player-game.model.ts
+++ b/src/main/webapp/app/entities/player-game/player-game.model.ts
@@ -8,7 +8,7 @@ export interface IPlayerGame {
   order?: number | null;
   isWinner?: boolean | null;
   game?: Pick<IGame, 'id'> | null;
-  userProfile?: Pick<IUserProfile, 'id'> | null;
+  userProfile?: IUserProfile | null;
 }
 
 export type NewPlayerGame = Omit<IPlayerGame, 'id'> & { id: null };

--- a/src/main/webapp/app/room/room.component.html
+++ b/src/main/webapp/app/room/room.component.html
@@ -2,4 +2,12 @@
   <label>Enlace para compartir:</label>
   <input type="text" class="form-control" [value]="shareLink()" readonly />
 </div>
+
+<ul class="list-group mb-3">
+  <li *ngFor="let player of players()" class="list-group-item">
+    {{ player.userProfile?.nickname }}
+  </li>
+</ul>
+
+<button *ngIf="game() && game()!.status === 'WAITING'" class="btn btn-success mb-3" (click)="startGame()">Iniciar partida</button>
 <jhi-phaser-game *ngIf="game() && game()!.status === 'IN_PROGRESS'" [game]="game()"></jhi-phaser-game>

--- a/src/main/webapp/app/room/room.component.ts
+++ b/src/main/webapp/app/room/room.component.ts
@@ -6,7 +6,8 @@ import { GameService } from '../entities/game/service/game.service';
 import { IGame } from '../entities/game/game.model';
 import { UserProfileService } from '../entities/user-profile/service/user-profile.service';
 import { PlayerGameService } from '../entities/player-game/service/player-game.service';
-import { NewPlayerGame } from '../entities/player-game/player-game.model';
+import { IPlayerGame, NewPlayerGame } from '../entities/player-game/player-game.model';
+import { TrackerService } from '../core/tracker/tracker.service';
 
 @Component({
   selector: 'jhi-room',
@@ -17,11 +18,13 @@ import { NewPlayerGame } from '../entities/player-game/player-game.model';
 export default class RoomComponent implements OnInit {
   game = signal<IGame | null>(null);
   shareLink = signal('');
+  players = signal<IPlayerGame[]>([]);
 
   private readonly route = inject(ActivatedRoute);
   private readonly gameService = inject(GameService);
   private readonly userProfileService = inject(UserProfileService);
   private readonly playerGameService = inject(PlayerGameService);
+  private readonly trackerService = inject(TrackerService);
 
   ngOnInit(): void {
     const code = this.route.snapshot.paramMap.get('code')!;
@@ -48,7 +51,33 @@ export default class RoomComponent implements OnInit {
             }
           });
         }
+        this.loadPlayers();
+        this.trackerService.stomp.watch('/topic/games').subscribe(message => {
+          const updated = JSON.parse(message.body) as IGame;
+          if (updated.id === game.id) {
+            this.game.set(updated);
+            this.loadPlayers();
+          }
+        });
       }
     });
+  }
+
+  startGame(): void {
+    const g = this.game();
+    if (g?.id) {
+      this.gameService.start(g.id).subscribe(res => {
+        if (res.body) {
+          this.game.set(res.body);
+        }
+      });
+    }
+  }
+
+  private loadPlayers(): void {
+    const g = this.game();
+    if (g?.id) {
+      this.playerGameService.findByGame(g.id).subscribe(players => this.players.set(players));
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow starting a game on the server
- notify via websocket when players join
- expose endpoint in frontend game service
- display players in the room with a Start Game button

## Testing
- `npm test`
- `./mvnw -ntp -Dskip.npm verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba6ab0f483228b7be01afe29305a