### PR TITLE
Implement join game checks

### DIFF
--- a/src/main/java/com/cobijo/oca/repository/PlayerGameRepository.java
+++ b/src/main/java/com/cobijo/oca/repository/PlayerGameRepository.java
@@ -12,4 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PlayerGameRepository extends JpaRepository<PlayerGame, Long> {
     List<PlayerGame> findByGameId(Long gameId);
+
+    Optional<PlayerGame> findByGameIdAndUserProfileId(Long gameId, Long userProfileId);
 }

--- a/src/main/java/com/cobijo/oca/service/dto/JoinGameDTO.java
+++ b/src/main/java/com/cobijo/oca/service/dto/JoinGameDTO.java
@@ -1,0 +1,31 @@
+package com.cobijo.oca.service.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DTO used to join a game.
+ */
+public class JoinGameDTO {
+
+    @NotNull
+    private Long gameId;
+
+    @NotNull
+    private Long userProfileId;
+
+    public Long getGameId() {
+        return gameId;
+    }
+
+    public void setGameId(Long gameId) {
+        this.gameId = gameId;
+    }
+
+    public Long getUserProfileId() {
+        return userProfileId;
+    }
+
+    public void setUserProfileId(Long userProfileId) {
+        this.userProfileId = userProfileId;
+    }
+}

--- a/src/main/java/com/cobijo/oca/web/rest/PlayerGameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/PlayerGameResource.java
@@ -5,6 +5,7 @@ import com.cobijo.oca.service.GameService;
 import com.cobijo.oca.service.PlayerGameService;
 import com.cobijo.oca.service.dto.GameDTO;
 import com.cobijo.oca.service.dto.PlayerGameDTO;
+import com.cobijo.oca.service.dto.JoinGameDTO;
 import com.cobijo.oca.web.rest.errors.BadRequestAlertException;
 import com.cobijo.oca.web.websocket.GameWebsocketService;
 import jakarta.validation.Valid;
@@ -83,6 +84,18 @@ public class PlayerGameResource {
         return ResponseEntity.created(new URI("/api/player-games/" + playerGameDTO.getId()))
             .headers(HeaderUtil.createEntityCreationAlert(applicationName, false, ENTITY_NAME, playerGameDTO.getId().toString()))
             .body(playerGameDTO);
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<PlayerGameDTO> joinGame(@Valid @RequestBody JoinGameDTO joinGameDTO) {
+        LOG.debug("REST request to join game : {}", joinGameDTO);
+        PlayerGameDTO playerGameDTO = playerGameService.join(joinGameDTO.getGameId(), joinGameDTO.getUserProfileId());
+        if (playerGameDTO.getGame() != null && playerGameDTO.getGame().getId() != null) {
+            Long gameId = playerGameDTO.getGame().getId();
+            Optional<GameDTO> gameDTO = gameService.findOne(gameId);
+            gameDTO.ifPresent(gameWebsocketService::sendGameUpdate);
+        }
+        return ResponseEntity.ok(playerGameDTO);
     }
 
     /**

--- a/src/main/webapp/app/entities/player-game/service/player-game.service.ts
+++ b/src/main/webapp/app/entities/player-game/service/player-game.service.ts
@@ -48,6 +48,10 @@ export class PlayerGameService {
     return this.http.get<IPlayerGame[]>(`${this.resourceUrl}/game/${gameId}`);
   }
 
+  join(data: { gameId: number; userProfileId: number }): Observable<IPlayerGame> {
+    return this.http.post<IPlayerGame>(`${this.resourceUrl}/join`, data);
+  }
+
   delete(id: number): Observable<HttpResponse<{}>> {
     return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response' });
   }

--- a/src/main/webapp/app/room/room.component.ts
+++ b/src/main/webapp/app/room/room.component.ts
@@ -6,7 +6,7 @@ import { GameService } from '../entities/game/service/game.service';
 import { IGame } from '../entities/game/game.model';
 import { UserProfileService } from '../entities/user-profile/service/user-profile.service';
 import { PlayerGameService } from '../entities/player-game/service/player-game.service';
-import { IPlayerGame, NewPlayerGame } from '../entities/player-game/player-game.model';
+import { IPlayerGame } from '../entities/player-game/player-game.model';
 import { TrackerService } from '../core/tracker/tracker.service';
 
 @Component({
@@ -34,20 +34,11 @@ export default class RoomComponent implements OnInit {
       this.game.set(game);
       if (game) {
         const sessionId = localStorage.getItem('session_id');
-        if (sessionId) {
+        if (sessionId && game.status === 'WAITING') {
           this.userProfileService.findBySession(sessionId).subscribe(profileRes => {
             const profile = profileRes.body;
             if (profile?.id) {
-              const player: NewPlayerGame = {
-                id: null,
-                positionx: 0,
-                positiony: 0,
-                order: 0,
-                isWinner: false,
-                game: { id: game.id },
-                userProfile: { id: profile.id },
-              };
-              this.playerGameService.create(player).subscribe();
+              this.playerGameService.join({ gameId: game.id!, userProfileId: profile.id }).subscribe();
             }
           });
         }


### PR DESCRIPTION
## Summary
- avoid duplicate players in games
- disallow joining once a game has started
- expose `/api/player-games/join` endpoint
- show existing games on home and respect game status when joining

## Testing
- `npm test` *(fails: Cannot find package 'globals')*
- `./mvnw -ntp verify` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849c219b6cc8322967f3d77d66eb1aa