### PR TITLE
Implement dice logic with turn tracking

### DIFF
--- a/src/main/java/com/cobijo/oca/repository/PlayerGameRepository.java
+++ b/src/main/java/com/cobijo/oca/repository/PlayerGameRepository.java
@@ -14,5 +14,7 @@ import org.springframework.stereotype.Repository;
 public interface PlayerGameRepository extends JpaRepository<PlayerGame, Long> {
     List<PlayerGame> findByGameId(Long gameId);
 
+    List<PlayerGame> findByGameIdOrderByOrder(Long gameId);
+
     Optional<PlayerGame> findByGameIdAndUserProfileId(Long gameId, Long userProfileId);
 }

--- a/src/main/java/com/cobijo/oca/web/rest/GameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/GameResource.java
@@ -2,6 +2,7 @@ package com.cobijo.oca.web.rest;
 
 import com.cobijo.oca.repository.GameRepository;
 import com.cobijo.oca.service.GameService;
+import com.cobijo.oca.service.PlayerGameService;
 import com.cobijo.oca.service.dto.GameDTO;
 import com.cobijo.oca.web.rest.errors.BadRequestAlertException;
 import com.cobijo.oca.web.websocket.GameWebsocketService;
@@ -41,14 +42,22 @@ public class GameResource {
 
     private final GameService gameService;
 
+    private final PlayerGameService playerGameService;
+
     private final GameRepository gameRepository;
 
     private final GameWebsocketService gameWebsocketService;
 
-    public GameResource(GameService gameService, GameRepository gameRepository, GameWebsocketService gameWebsocketService) {
+    public GameResource(
+        GameService gameService,
+        GameRepository gameRepository,
+        GameWebsocketService gameWebsocketService,
+        PlayerGameService playerGameService
+    ) {
         this.gameService = gameService;
         this.gameRepository = gameRepository;
         this.gameWebsocketService = gameWebsocketService;
+        this.playerGameService = playerGameService;
     }
 
     /**
@@ -81,6 +90,14 @@ public class GameResource {
     public ResponseEntity<GameDTO> startGame(@PathVariable("id") Long id) {
         LOG.debug("REST request to start Game : {}", id);
         GameDTO gameDTO = gameService.startGame(id);
+        gameWebsocketService.sendGameUpdate(gameDTO);
+        return ResponseEntity.ok().body(gameDTO);
+    }
+
+    @PostMapping("/{id}/roll")
+    public ResponseEntity<GameDTO> rollDice(@PathVariable("id") Long id) {
+        LOG.debug("REST request to roll dice for game : {}", id);
+        GameDTO gameDTO = playerGameService.rollDice(id);
         gameWebsocketService.sendGameUpdate(gameDTO);
         return ResponseEntity.ok().body(gameDTO);
     }

--- a/src/main/webapp/app/entities/game/service/game.service.ts
+++ b/src/main/webapp/app/entities/game/service/game.service.ts
@@ -52,6 +52,10 @@ export class GameService {
     return this.http.post<IGame>(`${this.resourceUrl}/${id}/start`, {}, { observe: 'response' });
   }
 
+  roll(id: number): Observable<EntityResponseType> {
+    return this.http.post<IGame>(`${this.resourceUrl}/${id}/roll`, {}, { observe: 'response' });
+  }
+
   findByCode(code: string): Observable<EntityResponseType> {
     return this.http.get<IGame>(`${this.resourceUrl}/code/${code}`, { observe: 'response' });
   }

--- a/src/main/webapp/app/phaser-game/scene.ts
+++ b/src/main/webapp/app/phaser-game/scene.ts
@@ -55,6 +55,15 @@ export class MainScene extends Phaser.Scene {
     }
   }
 
+  setPlayerPosition(index: number, position: number): void {
+    const player = this.players[index];
+    player.position = position % (BOARD_ROWS * BOARD_COLS);
+    const { row, col } = this.indexToCoord(player.position);
+    if (player.sprite) {
+      player.sprite.setPosition(col * TILE_SIZE + TILE_SIZE / 2, row * TILE_SIZE + TILE_SIZE / 2);
+    }
+  }
+
   private indexToCoord(index: number): { row: number; col: number } {
     const row = Math.floor(index / BOARD_COLS);
     const col = index % BOARD_COLS;


### PR DESCRIPTION
## Summary
- store players ordered by turn and include query
- compute new board position and switch turns on dice roll
- expose POST `/games/{id}/roll` to move players
- update frontend services and components for backend-driven moves
- support updating token position directly in Phaser scene

## Testing
- `./mvnw -ntp -Dskip.installnodenpm -Dskip.npm verify` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6849c66dab008322a05d4e13000b1783