### PR TITLE
Update turn logic with websocket sync

### DIFF
--- a/src/main/webapp/app/phaser-game/phaser-game.component.html
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.html
@@ -1,5 +1,5 @@
 <div class="mb-2">
-  <button class="btn btn-primary" (click)="rollDice()">Tirar dado</button>
+  <button class="btn btn-primary" (click)="rollDice()" *ngIf="isMyTurn">Tirar dado</button>
   <span class="ms-2" *ngIf="diceValue">Dado: {{ diceValue }}</span>
 </div>
 <div #gameContainer></div>


### PR DESCRIPTION
## Summary
- use OnChanges to sync game state when websocket updates
- track active player locally and restrict dice roll button
- hide dice button when it's not your turn

## Testing
- `npm test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6849c9f51ae08322bcba36af281bfd02