### PR TITLE
Filter home games by status

### DIFF
--- a/src/main/java/com/cobijo/oca/repository/GameRepository.java
+++ b/src/main/java/com/cobijo/oca/repository/GameRepository.java
@@ -1,11 +1,13 @@
 package com.cobijo.oca.repository;
 
 import com.cobijo.oca.domain.Game;
+import com.cobijo.oca.domain.enumeration.GameStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -33,4 +35,7 @@ public interface GameRepository extends GameRepositoryWithBagRelationships, JpaR
     default Optional<Game> findOneWithEagerRelationshipsByCode(String code) {
         return this.fetchBagRelationships(this.findOneByCode(code));
     }
+
+    @Query("select distinct g from Game g left join fetch g.userProfiles u where u.id = :userId and g.status in :statuses")
+    List<Game> findByUserAndStatuses(@Param("userId") Long userId, @Param("statuses") List<GameStatus> statuses);
 }

--- a/src/main/java/com/cobijo/oca/service/GameService.java
+++ b/src/main/java/com/cobijo/oca/service/GameService.java
@@ -5,6 +5,7 @@ import com.cobijo.oca.domain.enumeration.GameStatus;
 import com.cobijo.oca.repository.GameRepository;
 import com.cobijo.oca.service.dto.GameDTO;
 import com.cobijo.oca.service.mapper.GameMapper;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -131,6 +132,13 @@ public class GameService {
     public Optional<GameDTO> findOneByCode(String code) {
         LOG.debug("Request to get Game by code : {}", code);
         return gameRepository.findOneWithEagerRelationshipsByCode(code).map(gameMapper::toDto);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GameDTO> findActiveByUser(Long userId) {
+        LOG.debug("Request to get active games for user : {}", userId);
+        List<Game> games = gameRepository.findByUserAndStatuses(userId, List.of(GameStatus.WAITING, GameStatus.IN_PROGRESS));
+        return games.stream().map(gameMapper::toDto).toList();
     }
 
     /**

--- a/src/main/java/com/cobijo/oca/web/rest/GameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/GameResource.java
@@ -216,6 +216,13 @@ public class GameResource {
         return ResponseUtil.wrapOrNotFound(gameDTO);
     }
 
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<GameDTO>> getActiveGamesByUser(@PathVariable("userId") Long userId) {
+        LOG.debug("REST request to get active games for user : {}", userId);
+        List<GameDTO> list = gameService.findActiveByUser(userId);
+        return ResponseEntity.ok(list);
+    }
+
     /**
      * {@code DELETE  /games/:id} : delete the "id" game.
      *

--- a/src/main/webapp/app/entities/game/service/game.service.ts
+++ b/src/main/webapp/app/entities/game/service/game.service.ts
@@ -60,6 +60,10 @@ export class GameService {
     return this.http.get<IGame>(`${this.resourceUrl}/code/${code}`, { observe: 'response' });
   }
 
+  findByUser(userId: number): Observable<EntityArrayResponseType> {
+    return this.http.get<IGame[]>(`${this.resourceUrl}/user/${userId}`, { observe: 'response' });
+  }
+
   getGameIdentifier(game: Pick<IGame, 'id'>): number {
     return game.id;
   }

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -73,10 +73,8 @@ export default class HomeComponent implements OnInit, OnDestroy {
     this.userProfileService.findBySession(sessionId).subscribe(profileRes => {
       const profile = profileRes.body;
       if (profile?.id != null) {
-        this.gameService.query({ eagerload: true, size: 1000 }).subscribe(res => {
-          const games = res.body ?? [];
-          const filtered = games.filter(g => g.userProfiles?.some(u => u.id === profile.id));
-          this.games.set(filtered);
+        this.gameService.findByUser(profile.id).subscribe(res => {
+          this.games.set(res.body ?? []);
         });
       }
     });


### PR DESCRIPTION
## Summary
- filter IN_PROGRESS/WAITING games when listing rooms on home screen
- add new backend endpoint to fetch active games for a user
- connect frontend home page to use that endpoint

## Testing
- `npmw test`
- `mvnw -q verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4ee5ec483229fd60d7e5fc57ae0