### PR TITLE
Fix findByUserAndStatuses query

### DIFF
--- a/src/main/java/com/cobijo/oca/repository/GameRepository.java
+++ b/src/main/java/com/cobijo/oca/repository/GameRepository.java
@@ -36,6 +36,15 @@ public interface GameRepository extends GameRepositoryWithBagRelationships, JpaR
         return this.fetchBagRelationships(this.findOneByCode(code));
     }
 
-    @Query("select distinct g from Game g left join fetch g.userProfiles u where u.id = :userId and g.status in :statuses")
-    List<Game> findByUserAndStatuses(@Param("userId") Long userId, @Param("statuses") List<GameStatus> statuses);
+    @Query(
+        "select distinct g from Game g " +
+        "left join fetch g.userProfiles up " +
+        "join g.playerGames pg " +
+        "join pg.userProfile pgu " +
+        "where pgu.id = :userId and g.status in :statuses"
+    )
+    List<Game> findByUserAndStatuses(
+        @Param("userId") Long userId,
+        @Param("statuses") List<GameStatus> statuses
+    );
 }


### PR DESCRIPTION
## Summary
- join on PlayerGame to filter results while still fetching all user profiles

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6849f0baadbc83229f2c4338ba554a52