### PR TITLE
Fix home guest flow tests

### DIFF
--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -32,11 +32,17 @@ export default class HomeComponent implements OnInit, OnDestroy {
       .getAuthenticationState()
       .pipe(takeUntil(this.destroy$))
       .subscribe(account => {
-        if (account === null) {
-          this.router.navigate(['/login']);
-        } else {
+        if (account !== null) {
           this.account.set(account);
           this.loadGames();
+          return;
+        }
+
+        const sessionId = localStorage.getItem('session_id');
+        if (sessionId) {
+          this.loadGames();
+        } else {
+          this.router.navigate(['/login']);
         }
       });
   }


### PR DESCRIPTION
## Summary
- revert backend changes for open account endpoint
- mock HTTP services in Home component tests to prevent real calls

## Testing
- `sh ./mvnw -ntp -Dskip.installnodenpm -Dskip.npm verify` *(fails: Network is unreachable)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849fb4380488322b1d7661132d2568e