### PR TITLE
Improve Phaser board responsiveness

### DIFF
--- a/src/main/webapp/app/phaser-game/phaser-game.component.html
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.html
@@ -2,5 +2,5 @@
   <button class="btn btn-primary" (click)="rollDice()" *ngIf="isMyTurn">Tirar dado</button>
   <span class="ms-2" *ngIf="diceValue">Dado: {{ diceValue }}</span>
 </div>
-<div #gameContainer></div>
+<div id="gameContainer" #gameContainer></div>
 <jhi-dice-animation *ngIf="showDice" [value]="diceValue" [rolling]="rolling"></jhi-dice-animation>

--- a/src/main/webapp/app/phaser-game/phaser-game.component.scss
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+#gameContainer {
+  width: 100%;
+  margin: 0 auto;
+}

--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -78,12 +78,16 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
       position: (p.positiony ?? 0) * 8 + (p.positionx ?? 0),
     }));
     this.scene = new MainScene(tokens);
+    const containerWidth = this.gameContainer.nativeElement.offsetWidth || window.innerWidth;
+    const width = Math.min(800, containerWidth);
+    const height = width * 0.7;
     const config: Phaser.Types.Core.GameConfig = {
       type: Phaser.AUTO,
-      width: 800,
-      height: 600,
+      width,
+      height,
       parent: this.gameContainer.nativeElement,
       scene: [this.scene],
+      scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH },
     };
     this.phaserGame = new Phaser.Game(config);
   }

--- a/src/main/webapp/app/phaser-game/scene.ts
+++ b/src/main/webapp/app/phaser-game/scene.ts
@@ -2,7 +2,7 @@ import Phaser from 'phaser';
 
 export const BOARD_ROWS = 8;
 export const BOARD_COLS = 8;
-export const TILE_SIZE = 64;
+export const TILE_SIZE = 64; // Default size, will be overridden for responsive layout
 export interface PlayerToken {
   id: number;
   color: number;
@@ -12,6 +12,8 @@ export interface PlayerToken {
 
 export class MainScene extends Phaser.Scene {
   private players: PlayerToken[] = [];
+  private tileWidth = TILE_SIZE;
+  private tileHeight = TILE_SIZE;
   constructor(players: PlayerToken[]) {
     super({ key: 'MainScene' });
     this.players = players;
@@ -25,18 +27,25 @@ export class MainScene extends Phaser.Scene {
     const board = this.add.image(0, 0, 'board').setOrigin(0, 0);
 
     board.setDisplaySize(this.scale.width, this.scale.height);
+    this.tileWidth = this.scale.width / BOARD_COLS;
+    this.tileHeight = this.scale.height / BOARD_ROWS;
     for (let row = 0; row < BOARD_ROWS; row++) {
       for (let col = 0; col < BOARD_COLS; col++) {
-        const x = col * TILE_SIZE;
-        const y = row * TILE_SIZE;
+        const x = col * this.tileWidth;
+        const y = row * this.tileHeight;
         const color = (row + col) % 2 === 0 ? 0xffffff : 0xcccccc;
-        const rect = this.add.rectangle(x + TILE_SIZE / 2, y + TILE_SIZE / 2, TILE_SIZE, TILE_SIZE, color);
+        const rect = this.add.rectangle(x + this.tileWidth / 2, y + this.tileHeight / 2, this.tileWidth, this.tileHeight, color);
         rect.setStrokeStyle(1, 0x000000);
       }
     }
     this.players.forEach(p => {
       const { row, col } = this.indexToCoord(p.position);
-      p.sprite = this.add.circle(col * TILE_SIZE + TILE_SIZE / 2, row * TILE_SIZE + TILE_SIZE / 2, 20, p.color);
+      p.sprite = this.add.circle(
+        col * this.tileWidth + this.tileWidth / 2,
+        row * this.tileHeight + this.tileHeight / 2,
+        Math.min(this.tileWidth, this.tileHeight) / 3,
+        p.color,
+      );
     });
   }
 
@@ -47,8 +56,8 @@ export class MainScene extends Phaser.Scene {
     if (player.sprite) {
       this.tweens.add({
         targets: player.sprite,
-        x: col * TILE_SIZE + TILE_SIZE / 2,
-        y: row * TILE_SIZE + TILE_SIZE / 2,
+        x: col * this.tileWidth + this.tileWidth / 2,
+        y: row * this.tileHeight + this.tileHeight / 2,
         duration: 300,
         ease: 'Power2',
       });
@@ -60,7 +69,7 @@ export class MainScene extends Phaser.Scene {
     player.position = position % (BOARD_ROWS * BOARD_COLS);
     const { row, col } = this.indexToCoord(player.position);
     if (player.sprite) {
-      player.sprite.setPosition(col * TILE_SIZE + TILE_SIZE / 2, row * TILE_SIZE + TILE_SIZE / 2);
+      player.sprite.setPosition(col * this.tileWidth + this.tileWidth / 2, row * this.tileHeight + this.tileHeight / 2);
     }
   }
 


### PR DESCRIPTION
## Summary
- add dynamic sizing logic for Phaser board
- adjust board scene to scale with container
- add container styling for responsive game canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b39b9c330832292c7dcc2e6a705fb