### PR TITLE
Implement path-based movement logic

### DIFF
--- a/src/main/java/com/cobijo/oca/service/PlayerGameService.java
+++ b/src/main/java/com/cobijo/oca/service/PlayerGameService.java
@@ -30,6 +30,8 @@ public class PlayerGameService {
 
     private static final Logger LOG = LoggerFactory.getLogger(PlayerGameService.class);
 
+    private static final int[][] VALID_PATH = { { 3, 15 }, { 8, 15 } };
+
     private final PlayerGameRepository playerGameRepository;
 
     private final GameRepository gameRepository;
@@ -52,6 +54,15 @@ public class PlayerGameService {
         this.userProfileRepository = userProfileRepository;
         this.playerGameMapper = playerGameMapper;
         this.gameMapper = gameMapper;
+    }
+
+    private int coordToIndex(int row, int col) {
+        for (int i = 0; i < VALID_PATH.length; i++) {
+            if (VALID_PATH[i][0] == row && VALID_PATH[i][1] == col) {
+                return i;
+            }
+        }
+        return 0;
     }
 
     /**
@@ -132,8 +143,8 @@ public class PlayerGameService {
         PlayerGame pg = new PlayerGame();
         pg.setGame(game);
         pg.setUserProfile(userProfile);
-        pg.setPositionx(0);
-        pg.setPositiony(0);
+        pg.setPositiony(VALID_PATH[0][0]);
+        pg.setPositionx(VALID_PATH[0][1]);
         pg.setOrder(playerGameRepository.findByGameIdOrderByOrder(gameId).size());
         pg.setIsWinner(false);
         pg = playerGameRepository.save(pg);
@@ -175,12 +186,10 @@ public class PlayerGameService {
 
         PlayerGame currentPlayer = players.get(currentTurn);
         int dice = (int) (Math.random() * 6) + 1;
-        int boardCols = 8;
-        int boardRows = 8;
-        int index = currentPlayer.getPositiony() * boardCols + currentPlayer.getPositionx();
-        int newIndex = (index + dice) % (boardCols * boardRows);
-        currentPlayer.setPositionx(newIndex % boardCols);
-        currentPlayer.setPositiony(newIndex / boardCols);
+        int index = coordToIndex(currentPlayer.getPositiony(), currentPlayer.getPositionx());
+        int newIndex = (index + dice) % VALID_PATH.length;
+        currentPlayer.setPositiony(VALID_PATH[newIndex][0]);
+        currentPlayer.setPositionx(VALID_PATH[newIndex][1]);
         playerGameRepository.save(currentPlayer);
 
         game.setCurrentTurn((currentTurn + 1) % players.size());

--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject } from '@angular/core';
 import Phaser from 'phaser';
-import { MainScene, PlayerToken } from './scene';
+import { MainScene, PlayerToken, coordToIndex, VALID_PATH } from './scene';
 import { IGame } from 'app/entities/game/game.model';
 import { IPlayerGame } from 'app/entities/player-game/player-game.model';
 import { PlayerGameService } from 'app/entities/player-game/service/player-game.service';
@@ -75,7 +75,7 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
     const tokens: PlayerToken[] = this.players.map(p => ({
       id: p.id,
       color: Phaser.Display.Color.RandomRGB().color,
-      position: (p.positiony ?? 0) * 8 + (p.positionx ?? 0),
+      position: coordToIndex(p.positiony ?? 0, p.positionx ?? 0),
     }));
     this.scene = new MainScene(tokens);
     const containerWidth = this.gameContainer.nativeElement.offsetWidth || window.innerWidth;
@@ -106,10 +106,10 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
         this.startGame();
       } else {
         players.forEach((p, idx) => {
-          const pos = (p.positiony ?? 0) * 8 + (p.positionx ?? 0);
+          const pos = coordToIndex(p.positiony ?? 0, p.positionx ?? 0);
           if (prevPlayers[idx]) {
-            const oldPos = (prevPlayers[idx].positiony ?? 0) * 8 + (prevPlayers[idx].positionx ?? 0);
-            const total = 8 * 8;
+            const oldPos = coordToIndex(prevPlayers[idx].positiony ?? 0, prevPlayers[idx].positionx ?? 0);
+            const total = VALID_PATH.length;
             let steps = pos - oldPos;
             if (steps < 0) {
               steps += total;

--- a/src/main/webapp/app/phaser-game/scene.ts
+++ b/src/main/webapp/app/phaser-game/scene.ts
@@ -1,9 +1,19 @@
 import Phaser from 'phaser';
 
-export const VALID_PATH = [
+export const VALID_PATH: [number, number][] = [
   [3, 15],
   [8, 15],
 ];
+
+export function coordToIndex(row: number, col: number): number {
+  for (let i = 0; i < VALID_PATH.length; i++) {
+    const [r, c] = VALID_PATH[i];
+    if (r === row && c === col) {
+      return i;
+    }
+  }
+  return 0;
+}
 export const BOARD_ROWS = 16;
 export const BOARD_COLS = 16;
 export const TILE_SIZE = 64; // Default size, will be overridden for responsive layout
@@ -55,7 +65,7 @@ export class MainScene extends Phaser.Scene {
 
   movePlayer(index: number, steps: number): void {
     const player = this.players[index];
-    player.position = (player.position + steps) % (BOARD_ROWS * BOARD_COLS);
+    player.position = (player.position + steps) % VALID_PATH.length;
     const { row, col } = this.indexToCoord(player.position);
     if (player.sprite) {
       this.tweens.add({
@@ -70,7 +80,7 @@ export class MainScene extends Phaser.Scene {
 
   setPlayerPosition(index: number, position: number): void {
     const player = this.players[index];
-    player.position = position % (BOARD_ROWS * BOARD_COLS);
+    player.position = position % VALID_PATH.length;
     const { row, col } = this.indexToCoord(player.position);
     if (player.sprite) {
       player.sprite.setPosition(col * this.tileWidth + this.tileWidth / 2, row * this.tileHeight + this.tileHeight / 2);
@@ -78,8 +88,7 @@ export class MainScene extends Phaser.Scene {
   }
 
   private indexToCoord(index: number): { row: number; col: number } {
-    const row = Math.floor(index / BOARD_COLS);
-    const col = index % BOARD_COLS;
+    const [row, col] = VALID_PATH[index % VALID_PATH.length];
     return { row, col };
   }
 }


### PR DESCRIPTION
## Summary
- map token moves to `VALID_PATH` coordinates
- calculate path index from coordinates in front-end and back-end
- ensure new players start on the first path square

## Testing
- `./npmw run prettier:format`
- `./npmw test`
- `./mvnw -ntp verify -Dskip.npm` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c663a308322a3be5f7534ea09d0