### PR TITLE
Handle invalid guest token

### DIFF
--- a/src/main/webapp/app/core/auth/user-route-access.service.ts
+++ b/src/main/webapp/app/core/auth/user-route-access.service.ts
@@ -1,38 +1,57 @@
 import { inject, isDevMode } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot } from '@angular/router';
-import { map } from 'rxjs/operators';
+import { map, switchMap, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 import { AccountService } from 'app/core/auth/account.service';
 import { StateStorageService } from './state-storage.service';
+import { UserProfileService } from 'app/entities/user-profile/service/user-profile.service';
 
 export const UserRouteAccessService: CanActivateFn = (next: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
   const accountService = inject(AccountService);
   const router = inject(Router);
   const stateStorageService = inject(StateStorageService);
+  const userProfileService = inject(UserProfileService);
   return accountService.identity().pipe(
-    map(account => {
+    switchMap(account => {
       if (account) {
         const { authorities } = next.data;
 
         if (!authorities || authorities.length === 0 || accountService.hasAnyAuthority(authorities)) {
-          return true;
+          return of(true);
         }
 
         if (isDevMode()) {
           console.error('User does not have any of the required authorities:', authorities);
         }
         router.navigate(['accessdenied']);
-        return false;
+        return of(false);
       }
 
       const guestSession = localStorage.getItem('session_id');
       if (guestSession) {
-        return true;
+        return userProfileService.findBySession(guestSession).pipe(
+          map(profileRes => {
+            if (profileRes.body) {
+              return true;
+            }
+            localStorage.removeItem('session_id');
+            stateStorageService.storeUrl(state.url);
+            router.navigate(['/login']);
+            return false;
+          }),
+          catchError(() => {
+            localStorage.removeItem('session_id');
+            stateStorageService.storeUrl(state.url);
+            router.navigate(['/login']);
+            return of(false);
+          }),
+        );
       }
 
       stateStorageService.storeUrl(state.url);
       router.navigate(['/login']);
-      return false;
+      return of(false);
     }),
   );
 };

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -76,13 +76,22 @@ export default class HomeComponent implements OnInit, OnDestroy {
     if (!sessionId) {
       return;
     }
-    this.userProfileService.findBySession(sessionId).subscribe(profileRes => {
-      const profile = profileRes.body;
-      if (profile?.id != null) {
-        this.gameService.findByUser(profile.id).subscribe(res => {
-          this.games.set(res.body ?? []);
-        });
-      }
+    this.userProfileService.findBySession(sessionId).subscribe({
+      // eslint-disable-next-line object-shorthand
+      next: profileRes => {
+        const profile = profileRes.body;
+        if (profile?.id != null) {
+          this.gameService.findByUser(profile.id).subscribe(res => {
+            this.games.set(res.body ?? []);
+          });
+        } else {
+          localStorage.removeItem('session_id');
+        }
+      },
+      // eslint-disable-next-line object-shorthand
+      error: () => {
+        localStorage.removeItem('session_id');
+      },
     });
   }
 }

--- a/src/main/webapp/app/room/room.component.ts
+++ b/src/main/webapp/app/room/room.component.ts
@@ -35,11 +35,20 @@ export default class RoomComponent implements OnInit {
       if (game) {
         const sessionId = localStorage.getItem('session_id');
         if (sessionId && game.status === 'WAITING') {
-          this.userProfileService.findBySession(sessionId).subscribe(profileRes => {
-            const profile = profileRes.body;
-            if (profile?.id) {
-              this.playerGameService.join({ gameId: game.id, userProfileId: profile.id }).subscribe();
-            }
+          this.userProfileService.findBySession(sessionId).subscribe({
+            // eslint-disable-next-line object-shorthand
+            next: profileRes => {
+              const profile = profileRes.body;
+              if (profile?.id) {
+                this.playerGameService.join({ gameId: game.id, userProfileId: profile.id }).subscribe();
+              } else {
+                localStorage.removeItem('session_id');
+              }
+            },
+            // eslint-disable-next-line object-shorthand
+            error: () => {
+              localStorage.removeItem('session_id');
+            },
           });
         }
         this.loadPlayers();


### PR DESCRIPTION
## Summary
- clear session token if UserProfile lookups fail
- join game only for valid guest tokens
- validate guest sessions when accessing protected routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508e78c8808322b45b97c50c9125a3