### PR TITLE
Implement shared dice roll animation

### DIFF
--- a/src/main/java/com/cobijo/oca/service/PlayerGameService.java
+++ b/src/main/java/com/cobijo/oca/service/PlayerGameService.java
@@ -9,6 +9,7 @@ import com.cobijo.oca.repository.PlayerGameRepository;
 import com.cobijo.oca.repository.UserProfileRepository;
 import com.cobijo.oca.service.dto.GameDTO;
 import com.cobijo.oca.service.dto.PlayerGameDTO;
+import com.cobijo.oca.web.websocket.dto.DiceRollDTO;
 import com.cobijo.oca.service.mapper.GameMapper;
 import com.cobijo.oca.service.mapper.PlayerGameMapper;
 import java.util.List;
@@ -161,7 +162,7 @@ public class PlayerGameService {
         playerGameRepository.deleteById(id);
     }
 
-    public GameDTO rollDice(Long gameId) {
+    public DiceRollDTO rollDice(Long gameId) {
         LOG.debug("Request to roll dice for game : {}", gameId);
         Game game = gameRepository.findById(gameId).orElseThrow();
         List<PlayerGame> players = playerGameRepository.findByGameIdOrderByOrder(gameId);
@@ -182,6 +183,6 @@ public class PlayerGameService {
         game.setCurrentTurn((currentTurn + 1) % players.size());
         game = gameRepository.save(game);
 
-        return gameMapper.toDto(game);
+        return new DiceRollDTO(gameMapper.toDto(game), dice);
     }
 }

--- a/src/main/java/com/cobijo/oca/web/rest/GameResource.java
+++ b/src/main/java/com/cobijo/oca/web/rest/GameResource.java
@@ -4,6 +4,7 @@ import com.cobijo.oca.repository.GameRepository;
 import com.cobijo.oca.service.GameService;
 import com.cobijo.oca.service.PlayerGameService;
 import com.cobijo.oca.service.dto.GameDTO;
+import com.cobijo.oca.web.websocket.dto.DiceRollDTO;
 import com.cobijo.oca.web.rest.errors.BadRequestAlertException;
 import com.cobijo.oca.web.websocket.GameWebsocketService;
 import jakarta.validation.Valid;
@@ -95,11 +96,11 @@ public class GameResource {
     }
 
     @PostMapping("/{id}/roll")
-    public ResponseEntity<GameDTO> rollDice(@PathVariable("id") Long id) {
+    public ResponseEntity<DiceRollDTO> rollDice(@PathVariable("id") Long id) {
         LOG.debug("REST request to roll dice for game : {}", id);
-        GameDTO gameDTO = playerGameService.rollDice(id);
-        gameWebsocketService.sendGameUpdate(gameDTO);
-        return ResponseEntity.ok().body(gameDTO);
+        DiceRollDTO dto = playerGameService.rollDice(id);
+        gameWebsocketService.sendDiceRoll(dto);
+        return ResponseEntity.ok().body(dto);
     }
 
     /**

--- a/src/main/java/com/cobijo/oca/web/websocket/GameWebsocketService.java
+++ b/src/main/java/com/cobijo/oca/web/websocket/GameWebsocketService.java
@@ -1,6 +1,7 @@
 package com.cobijo.oca.web.websocket;
 
 import com.cobijo.oca.service.dto.GameDTO;
+import com.cobijo.oca.web.websocket.dto.DiceRollDTO;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +16,9 @@ public class GameWebsocketService {
 
     public void sendGameUpdate(GameDTO gameDTO) {
         messagingTemplate.convertAndSend("/topic/games", gameDTO);
+    }
+
+    public void sendDiceRoll(DiceRollDTO diceRollDTO) {
+        messagingTemplate.convertAndSend("/topic/dice", diceRollDTO);
     }
 }

--- a/src/main/java/com/cobijo/oca/web/websocket/dto/DiceRollDTO.java
+++ b/src/main/java/com/cobijo/oca/web/websocket/dto/DiceRollDTO.java
@@ -1,0 +1,36 @@
+package com.cobijo.oca.web.websocket.dto;
+
+import com.cobijo.oca.service.dto.GameDTO;
+
+/**
+ * DTO representing a dice roll event.
+ */
+public class DiceRollDTO {
+
+    private GameDTO game;
+
+    private int dice;
+
+    public DiceRollDTO() {}
+
+    public DiceRollDTO(GameDTO game, int dice) {
+        this.game = game;
+        this.dice = dice;
+    }
+
+    public GameDTO getGame() {
+        return game;
+    }
+
+    public void setGame(GameDTO game) {
+        this.game = game;
+    }
+
+    public int getDice() {
+        return dice;
+    }
+
+    public void setDice(int dice) {
+        this.dice = dice;
+    }
+}

--- a/src/main/webapp/app/entities/game/roll-result.model.ts
+++ b/src/main/webapp/app/entities/game/roll-result.model.ts
@@ -1,0 +1,6 @@
+import { IGame } from './game.model';
+
+export interface IRollResult {
+  game: IGame;
+  dice: number;
+}

--- a/src/main/webapp/app/entities/game/service/game.service.ts
+++ b/src/main/webapp/app/entities/game/service/game.service.ts
@@ -6,6 +6,7 @@ import { isPresent } from 'app/core/util/operators';
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
 import { createRequestOption } from 'app/core/request/request-util';
 import { IGame, NewGame } from '../game.model';
+import { IRollResult } from '../roll-result.model';
 
 export type PartialUpdateGame = Partial<IGame> & Pick<IGame, 'id'>;
 
@@ -52,8 +53,8 @@ export class GameService {
     return this.http.post<IGame>(`${this.resourceUrl}/${id}/start`, {}, { observe: 'response' });
   }
 
-  roll(id: number): Observable<EntityResponseType> {
-    return this.http.post<IGame>(`${this.resourceUrl}/${id}/roll`, {}, { observe: 'response' });
+  roll(id: number): Observable<HttpResponse<IRollResult>> {
+    return this.http.post<IRollResult>(`${this.resourceUrl}/${id}/roll`, {}, { observe: 'response' });
   }
 
   findByCode(code: string): Observable<EntityResponseType> {


### PR DESCRIPTION
## Summary
- add `DiceRollDTO` for backend and websocket
- broadcast dice rolls via websocket
- update dice roll logic in player service and resource
- adapt Angular service and component for synced dice rolls

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_685092b6b28083229d19be10c165c3ec