### PR TITLE
Add profile images to player tokens

### DIFF
--- a/src/main/webapp/app/phaser-game/phaser-game.component.spec.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.spec.ts
@@ -6,6 +6,7 @@ jest.mock('phaser', () => ({
   AUTO: 0,
   GameObjects: { Image: class {} },
 }));
+jest.mock('@stomp/rx-stomp', () => ({ RxStomp: class {} }));
 
 import { PhaserGameComponent } from './phaser-game.component';
 import { provideHttpClient } from '@angular/common/http';

--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject } from '@angular/core';
 import Phaser from 'phaser';
-import { MainScene, PlayerToken, BOARD_SIZE } from './scene';
+import { MainScene, PlayerToken, BOARD_SIZE, DEFAULT_TOKEN_COLORS } from './scene';
 import { IGame } from 'app/entities/game/game.model';
 import { IPlayerGame } from 'app/entities/player-game/player-game.model';
 import { PlayerGameService } from 'app/entities/player-game/service/player-game.service';
@@ -68,6 +68,10 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
     });
   }
 
+  ngOnDestroy(): void {
+    this.phaserGame?.destroy(true);
+  }
+
   private handleRollResult(roll: IRollResult): void {
     this.diceValue = roll.dice;
     this.currentTurn = roll.game.currentTurn ?? 0;
@@ -79,15 +83,12 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
     }, 1000);
   }
 
-  ngOnDestroy(): void {
-    this.phaserGame?.destroy(true);
-  }
-
   private startGame(): void {
     const tokens: PlayerToken[] = this.players.map(p => ({
       id: p.id,
-      color: Phaser.Display.Color.RandomRGB().color,
+      color: DEFAULT_TOKEN_COLORS[Math.floor(Math.random() * DEFAULT_TOKEN_COLORS.length)],
       position: p.position ?? 0,
+      avatarUrl: p.userProfile?.avatarUrl ?? null,
     }));
     this.scene = new MainScene(tokens);
     const containerWidth = this.gameContainer.nativeElement.offsetWidth || window.innerWidth;

--- a/src/main/webapp/app/phaser-game/scene.ts
+++ b/src/main/webapp/app/phaser-game/scene.ts
@@ -28,11 +28,13 @@ export const BOARD_ROWS = 16;
 export const BOARD_COLS = 16;
 export const BOARD_SIZE = BOARD_COORDS.length;
 export const TILE_SIZE = 64; // Default size, will be overridden for responsive layout
+export const DEFAULT_TOKEN_COLORS = [0xe57373, 0x64b5f6, 0x81c784, 0xffb74d, 0xba68c8, 0x4db6ac];
 export interface PlayerToken {
   id: number;
   color: number;
   position: number;
-  sprite?: Phaser.GameObjects.Arc;
+  avatarUrl?: string | null;
+  sprite?: Phaser.GameObjects.Container;
 }
 
 export class MainScene extends Phaser.Scene {
@@ -46,6 +48,11 @@ export class MainScene extends Phaser.Scene {
 
   preload(): void {
     this.load.image('board', 'content/images/tablero.jpg');
+    this.players.forEach(p => {
+      if (p.avatarUrl) {
+        this.load.image(`avatar-${p.id}`, p.avatarUrl);
+      }
+    });
   }
 
   create(): void {
@@ -65,12 +72,22 @@ export class MainScene extends Phaser.Scene {
     }
     this.players.forEach(p => {
       const { row, col } = this.indexToCoord(p.position);
-      p.sprite = this.add.circle(
-        col * this.tileWidth + this.tileWidth / 2,
-        row * this.tileHeight + this.tileHeight / 2,
-        Math.min(this.tileWidth, this.tileHeight) / 3,
-        p.color,
-      );
+      const x = col * this.tileWidth + this.tileWidth / 2;
+      const y = row * this.tileHeight + this.tileHeight / 2;
+      const radius = Math.min(this.tileWidth, this.tileHeight) / 3;
+      const container = this.add.container(x, y);
+      const circle = this.add.circle(0, 0, radius, p.color);
+      container.add(circle);
+      if (p.avatarUrl) {
+        const image = this.add.image(0, 0, `avatar-${p.id}`);
+        image.setDisplaySize(radius * 2, radius * 2);
+        const maskGraphics = this.make.graphics({ x: 0, y: 0 });
+        maskGraphics.fillStyle(0xffffff);
+        maskGraphics.fillCircle(0, 0, radius);
+        image.setMask(maskGraphics.createGeometryMask());
+        container.add(image);
+      }
+      p.sprite = container;
     });
   }
 


### PR DESCRIPTION
## Summary
- display user avatars on board tokens
- use a predefined set of fallback colors
- mock RxStomp in tests to avoid ESM issues

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685094d430a88322baf5a3cf3a8a2244