### PR TITLE
Fix dice animation timing

### DIFF
--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -76,8 +76,8 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
     this.diceValue = roll.dice;
     this.currentTurn = roll.game.currentTurn ?? 0;
     this.showDice = true;
-    this.loadPlayers();
     setTimeout(() => {
+      this.loadPlayers();
       this.showDice = false;
       this.rolling = false;
     }, 1000);


### PR DESCRIPTION
## Summary
- show dice animation before updating piece positions

## Testing
- `npm test`
- `npm run backend:unit:test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851e26701208322bb6481f1d6baef31