### PR TITLE
Update navbar style

### DIFF
--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -1,4 +1,4 @@
-<nav data-cy="navbar" class="navbar navbar-dark navbar-expand-md bg-dark">
+<nav data-cy="navbar" class="navbar navbar-light navbar-expand-md main-navbar">
   <div class="container-fluid">
     <a class="navbar-brand logo" routerLink="/" (click)="collapseNavbar()">
       <span class="logo-img"></span>
@@ -23,64 +23,19 @@
           <a class="nav-link" routerLink="/" (click)="collapseNavbar()">
             <span>
               <fa-icon icon="home"></fa-icon>
-              <span>Inicio</span>
+              <span>Partidas</span>
             </span>
           </a>
         </li>
         <!-- jhipster-needle-add-element-to-menu - JHipster will add new menu items here -->
-        @if (account() !== null) {
-          <li
-            ngbDropdown
-            class="nav-item dropdown pointer"
-            display="dynamic"
-            routerLinkActive="active"
-            [routerLinkActiveOptions]="{ exact: true }"
-          >
-            <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="entity-menu" data-cy="entity">
+        @if (hasSessionToken()) {
+          <li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+            <a class="nav-link" routerLink="/user-profile" (click)="collapseNavbar()">
               <span>
-                <fa-icon icon="th-list"></fa-icon>
-                <span>Entidades</span>
+                <fa-icon icon="user"></fa-icon>
+                <span>Perfil de usuario</span>
               </span>
             </a>
-            <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="entity-menu">
-              <li>
-                <a
-                  class="dropdown-item"
-                  routerLink="/game"
-                  routerLinkActive="active"
-                  [routerLinkActiveOptions]="{ exact: true }"
-                  (click)="collapseNavbar()"
-                >
-                  <fa-icon icon="asterisk" [fixedWidth]="true"></fa-icon>
-                  <span>Game</span>
-                </a>
-              </li>
-              <li>
-                <a
-                  class="dropdown-item"
-                  routerLink="/player-game"
-                  routerLinkActive="active"
-                  [routerLinkActiveOptions]="{ exact: true }"
-                  (click)="collapseNavbar()"
-                >
-                  <fa-icon icon="asterisk" [fixedWidth]="true"></fa-icon>
-                  <span>Player Game</span>
-                </a>
-              </li>
-              <li>
-                <a
-                  class="dropdown-item"
-                  routerLink="/user-profile"
-                  routerLinkActive="active"
-                  [routerLinkActiveOptions]="{ exact: true }"
-                  (click)="collapseNavbar()"
-                >
-                  <fa-icon icon="asterisk" [fixedWidth]="true"></fa-icon>
-                  <span>User Profile</span>
-                </a>
-              </li>
-              <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
-            </ul>
           </li>
         }
         <li

--- a/src/main/webapp/app/layouts/navbar/navbar.component.scss
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.scss
@@ -7,7 +7,7 @@ Navbar
 
 .navbar-version {
   font-size: 0.65em;
-  color: $navbar-dark-color;
+  color: $navbar-light-color;
 }
 
 .profile-image {
@@ -21,6 +21,10 @@ Navbar
   a.nav-link {
     font-weight: 400;
   }
+}
+
+.main-navbar {
+  background-color: $body-bg;
 }
 
 /* ==========================================================================

--- a/src/main/webapp/app/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.ts
@@ -4,6 +4,7 @@ import { Router, RouterModule } from '@angular/router';
 import SharedModule from 'app/shared/shared.module';
 import HasAnyAuthorityDirective from 'app/shared/auth/has-any-authority.directive';
 import { AccountService } from 'app/core/auth/account.service';
+import { StateStorageService } from 'app/core/auth/state-storage.service';
 import { LoginService } from 'app/login/login.service';
 import { ProfileService } from 'app/layouts/profiles/profile.service';
 import { EntityNavbarItems } from 'app/entities/entity-navbar-items';
@@ -27,6 +28,7 @@ export default class NavbarComponent implements OnInit {
   private readonly loginService = inject(LoginService);
   private readonly profileService = inject(ProfileService);
   private readonly router = inject(Router);
+  private readonly stateStorageService = inject(StateStorageService);
 
   constructor() {
     const { VERSION } = environment;
@@ -55,6 +57,10 @@ export default class NavbarComponent implements OnInit {
     this.collapseNavbar();
     this.loginService.logout();
     this.router.navigate(['/login']);
+  }
+
+  hasSessionToken(): boolean {
+    return this.stateStorageService.getAuthenticationToken() !== null;
   }
 
   toggleNavbar(): void {

--- a/webpack/webpack.custom.js
+++ b/webpack/webpack.custom.js
@@ -31,6 +31,7 @@ module.exports = async (config, options, targetOptions) => {
     config.devServer.proxy = proxyConfig({ tls });
   }
 
+  // eslint-disable-next-line no-constant-condition, no-constant-binary-expression
   if (false && (targetOptions.target === 'serve' || config.watch)) {
     config.plugins.push(
       new BrowserSyncPlugin(


### PR DESCRIPTION
## Summary
- restyle navbar to match application background color
- simplify menu items to show matches and profile
- clean up lint issues in webpack config
- display profile option when a session token exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68545f0185248322aaaf082ae6e56b06