### PR TITLE
Add token-based profile route

### DIFF
--- a/src/main/webapp/app/entities/user-profile/route/user-profile-routing-resolve.service.ts
+++ b/src/main/webapp/app/entities/user-profile/route/user-profile-routing-resolve.service.ts
@@ -9,18 +9,29 @@ import { UserProfileService } from '../service/user-profile.service';
 
 const userProfileResolve = (route: ActivatedRouteSnapshot): Observable<null | IUserProfile> => {
   const id = route.params.id;
+  const sessionId = route.params.sessionId;
+  const service = inject(UserProfileService);
   if (id) {
-    return inject(UserProfileService)
-      .find(id)
-      .pipe(
-        mergeMap((userProfile: HttpResponse<IUserProfile>) => {
-          if (userProfile.body) {
-            return of(userProfile.body);
-          }
-          inject(Router).navigate(['404']);
-          return EMPTY;
-        }),
-      );
+    return service.find(id).pipe(
+      mergeMap((userProfile: HttpResponse<IUserProfile>) => {
+        if (userProfile.body) {
+          return of(userProfile.body);
+        }
+        inject(Router).navigate(['404']);
+        return EMPTY;
+      }),
+    );
+  }
+  if (sessionId) {
+    return service.findBySession(sessionId).pipe(
+      mergeMap((userProfile: HttpResponse<IUserProfile>) => {
+        if (userProfile.body) {
+          return of(userProfile.body);
+        }
+        inject(Router).navigate(['404']);
+        return EMPTY;
+      }),
+    );
   }
   return of(null);
 };

--- a/src/main/webapp/app/entities/user-profile/user-profile.routes.ts
+++ b/src/main/webapp/app/entities/user-profile/user-profile.routes.ts
@@ -22,6 +22,13 @@ const userProfileRoute: Routes = [
     canActivate: [UserRouteAccessService],
   },
   {
+    path: 'token/:sessionId/view',
+    loadComponent: () => import('./detail/user-profile-detail.component').then(m => m.UserProfileDetailComponent),
+    resolve: {
+      userProfile: UserProfileResolve,
+    },
+  },
+  {
     path: 'new',
     loadComponent: () => import('./update/user-profile-update.component').then(m => m.UserProfileUpdateComponent),
     resolve: {


### PR DESCRIPTION
## Summary
- allow resolving user profile by session token
- add unprotected route for token-based profile detail

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68547f8d4ff883228e446c6cc37ae1e9