### PR TITLE
Improve navbar profile button

### DIFF
--- a/src/main/webapp/app/entities/user-profile/user-profile.routes.ts
+++ b/src/main/webapp/app/entities/user-profile/user-profile.routes.ts
@@ -29,6 +29,13 @@ const userProfileRoute: Routes = [
     },
   },
   {
+    path: 'token/:sessionId/edit',
+    loadComponent: () => import('./update/user-profile-update.component').then(m => m.UserProfileUpdateComponent),
+    resolve: {
+      userProfile: UserProfileResolve,
+    },
+  },
+  {
     path: 'new',
     loadComponent: () => import('./update/user-profile-update.component').then(m => m.UserProfileUpdateComponent),
     resolve: {

--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -30,7 +30,7 @@
         <!-- jhipster-needle-add-element-to-menu - JHipster will add new menu items here -->
         @if (hasSessionToken()) {
           <li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
-            <a class="nav-link" routerLink="/user-profile" (click)="collapseNavbar()">
+            <a class="nav-link" (click)="goToProfile()">
               <span>
                 <fa-icon icon="user"></fa-icon>
                 <span>Perfil de usuario</span>

--- a/src/main/webapp/app/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.ts
@@ -63,6 +63,16 @@ export default class NavbarComponent implements OnInit {
     return this.stateStorageService.getAuthenticationToken() !== null;
   }
 
+  goToProfile(): void {
+    this.collapseNavbar();
+    const sessionId = localStorage.getItem('session_id');
+    if (sessionId) {
+      this.router.navigate(['/user-profile/token', sessionId, 'edit']);
+    } else {
+      this.router.navigate(['/login']);
+    }
+  }
+
   toggleNavbar(): void {
     this.isNavbarCollapsed.update(isNavbarCollapsed => !isNavbarCollapsed);
   }


### PR DESCRIPTION
## Summary
- route user profile edits via session token
- add `goToProfile()` in navbar
- navigate to profile edit from the navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855a49169cc832282ee2f3b10017a17