### PR TITLE
Add player carousel to game

### DIFF
--- a/src/main/webapp/app/phaser-game/phaser-game.component.html
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.html
@@ -6,6 +6,21 @@
     <span class="ms-2">Dado: {{ diceValue }}</span>
   }
 </div>
+@if (tokens.length > 0) {
+  <ngb-carousel class="mb-3" [interval]="0">
+    @for (token of tokens; let idx = $index) {
+      <ng-template ngbSlide>
+        <div class="d-flex align-items-center justify-content-center p-2">
+          <div class="token-circle" [style.backgroundColor]="getColor(token.color)"></div>
+          <span class="ms-2">Posición: {{ token.position }}</span>
+          @if (isTurn(idx)) {
+            <span class="badge bg-success ms-2">Turno</span>
+          }
+        </div>
+      </ng-template>
+    }
+  </ngb-carousel>
+}
 <div id="gameContainer" #gameContainer></div>
 
 @if (showDice) {

--- a/src/main/webapp/app/phaser-game/phaser-game.component.scss
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.scss
@@ -7,3 +7,9 @@
   width: 100%;
   margin: 0 auto;
 }
+
+.token-circle {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}

--- a/src/main/webapp/app/phaser-game/phaser-game.component.ts
+++ b/src/main/webapp/app/phaser-game/phaser-game.component.ts
@@ -8,10 +8,11 @@ import { GameService } from 'app/entities/game/service/game.service';
 import { IRollResult } from 'app/entities/game/roll-result.model';
 import { TrackerService } from 'app/core/tracker/tracker.service';
 import { DiceAnimationComponent } from './dice-animation/dice-animation.component';
+import SharedModule from 'app/shared/shared.module';
 
 @Component({
   selector: 'jhi-phaser-game',
-  imports: [DiceAnimationComponent],
+  imports: [SharedModule, DiceAnimationComponent],
   templateUrl: './phaser-game.component.html',
   styleUrl: './phaser-game.component.scss',
 })
@@ -25,6 +26,7 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
   currentTurn = 0;
   private myIndex = -1;
   private players: IPlayerGame[] = [];
+  private tokens: PlayerToken[] = [];
   private phaserGame?: Phaser.Game;
   private scene?: MainScene;
 
@@ -86,6 +88,14 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
     this.game = roll.game;
   }
 
+  isTurn(index: number): boolean {
+    return index === this.currentTurn;
+  }
+
+  getColor(color: number): string {
+    return `#${color.toString(16).padStart(6, '0')}`;
+  }
+
   private startGame(): void {
     const tokens: PlayerToken[] = this.players.map(p => ({
       id: p.id,
@@ -93,6 +103,7 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
       position: p.position ?? 0,
       avatarUrl: p.userProfile?.avatarUrl ?? null,
     }));
+    this.tokens = tokens;
     this.scene = new MainScene(tokens);
     const containerWidth = this.gameContainer.nativeElement.offsetWidth || window.innerWidth;
     const width = Math.min(800, containerWidth);
@@ -135,6 +146,9 @@ export class PhaserGameComponent implements OnDestroy, OnInit, OnChanges {
             }
           } else {
             this.scene!.setPlayerPosition(idx, pos);
+          }
+          if (this.tokens[idx]) {
+            this.tokens[idx].position = pos;
           }
         });
       }


### PR DESCRIPTION
## Summary
- show game players in a carousel when the match starts
- store tokens and expose their color and position
- style tokens for carousel

## Testing
- `npm test` *(fails: Cannot find package 'globals' during eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6855a7b021d48322ac2afae62c8a30cf