### PR TITLE
Restrict logos and users endpoints

### DIFF
--- a/src/main/java/com/cobijo/oca/config/SecurityConfiguration.java
+++ b/src/main/java/com/cobijo/oca/config/SecurityConfiguration.java
@@ -75,6 +75,8 @@ public class SecurityConfiguration {
                     .requestMatchers(mvc.pattern("/api/activate")).permitAll()
                     .requestMatchers(mvc.pattern("/api/account/reset-password/init")).permitAll()
                     .requestMatchers(mvc.pattern("/api/account/reset-password/finish")).permitAll()
+                    .requestMatchers(mvc.pattern(HttpMethod.GET, "/api/logos")).authenticated()
+                    .requestMatchers(mvc.pattern(HttpMethod.GET, "/api/users")).authenticated()
                     .requestMatchers(mvc.pattern("/api/admin/**")).hasAuthority(AuthoritiesConstants.ADMIN)
                     .requestMatchers(mvc.pattern("/api/**")).authenticated()
                     .requestMatchers(mvc.pattern("/websocket/**")).authenticated()


### PR DESCRIPTION
## Summary
- require JWT authentication for `/api/logos` and `/api/users`

## Testing
- `./mvnw -ntp verify` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6855b823c4f48322b7e7d86426f8d9a9