### PR TITLE
Adjust WebSocket tracking for session tokens

### DIFF
--- a/src/main/java/com/cobijo/oca/web/websocket/ActivityService.java
+++ b/src/main/java/com/cobijo/oca/web/websocket/ActivityService.java
@@ -28,8 +28,9 @@ public class ActivityService implements ApplicationListener<SessionDisconnectEve
     @MessageMapping("/topic/activity")
     @SendTo("/topic/tracker")
     public ActivityDTO sendActivity(@Payload ActivityDTO activityDTO, StompHeaderAccessor stompHeaderAccessor, Principal principal) {
-        activityDTO.setUserLogin(principal.getName());
-        activityDTO.setSessionId(stompHeaderAccessor.getSessionId());
+        String sessionToken = principal.getName();
+        activityDTO.setUserLogin(sessionToken);
+        activityDTO.setSessionId(sessionToken);
         activityDTO.setIpAddress(stompHeaderAccessor.getSessionAttributes().get(IP_ADDRESS).toString());
         activityDTO.setTime(Instant.now());
         LOG.debug("Sending user tracking data {}", activityDTO);

--- a/src/main/webapp/app/core/tracker/tracker.service.ts
+++ b/src/main/webapp/app/core/tracker/tracker.service.ts
@@ -34,7 +34,7 @@ export class TrackerService {
 
     this.accountService.getAuthenticationState().subscribe({
       next: (account: Account | null) => {
-        if (account) {
+        if (account || localStorage.getItem('session_id')) {
           this.connect();
         } else {
           this.disconnect();


### PR DESCRIPTION
## Summary
- track activity sessions via token IDs
- connect TrackerService for guest sessions via stored token

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6859c3c78e7c8322a23f62d7c243c85d