### PR TITLE
Fix WebSocket auth requirement

### DIFF
--- a/src/main/java/com/cobijo/oca/config/SecurityConfiguration.java
+++ b/src/main/java/com/cobijo/oca/config/SecurityConfiguration.java
@@ -80,7 +80,7 @@ public class SecurityConfiguration {
                     .requestMatchers(mvc.pattern(HttpMethod.GET, "/api/users")).permitAll()
                     .requestMatchers(mvc.pattern("/api/admin/**")).hasAuthority(AuthoritiesConstants.ADMIN)
                     .requestMatchers(mvc.pattern("/api/**")).authenticated()
-                    .requestMatchers(mvc.pattern("/websocket/**")).authenticated()
+                    .requestMatchers(mvc.pattern("/websocket/**")).permitAll()
                     .requestMatchers(mvc.pattern("/v3/api-docs/**")).hasAuthority(AuthoritiesConstants.ADMIN)
                     .requestMatchers(mvc.pattern("/management/health")).permitAll()
                     .requestMatchers(mvc.pattern("/management/health/**")).permitAll()


### PR DESCRIPTION
## Summary
- allow unauthenticated WebSocket connections so tracker service works for guests

## Testing
- `npm test`
- `./mvnw -ntp -Dskip.installnodenpm -Dskip.npm verify --batch-mode` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685d27dc270c83228335f2043860a1e6